### PR TITLE
binary-handling

### DIFF
--- a/src/main/java/uk/org/adamretter/restream/CachingFilterInputStream.java
+++ b/src/main/java/uk/org/adamretter/restream/CachingFilterInputStream.java
@@ -31,7 +31,7 @@ import uk.org.adamretter.restream.cache.FilterInputStreamCache;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import uk.org.adamretter.restream.cache.FileFilterInputStreamCache;
+
 
 /**
  * Implementation of an Input Stream that extends
@@ -119,7 +119,7 @@ public class CachingFilterInputStream extends FilterInputStream {
         } else {
             final int data = getCache().read();
             
-            if(data == FileFilterInputStreamCache.END_OF_STREAM) {
+            if(data == FilterInputStreamCache.END_OF_STREAM) {
                 return FilterInputStreamCache.END_OF_STREAM;
             }
             

--- a/src/main/java/uk/org/adamretter/restream/CachingFilterInputStream.java
+++ b/src/main/java/uk/org/adamretter/restream/CachingFilterInputStream.java
@@ -31,6 +31,7 @@ import uk.org.adamretter.restream.cache.FilterInputStreamCache;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import uk.org.adamretter.restream.cache.FileFilterInputStreamCache;
 
 /**
  * Implementation of an Input Stream that extends
@@ -51,43 +52,30 @@ public class CachingFilterInputStream extends FilterInputStream {
 
     //TODO what about if the underlying stream supports marking
     //then we could just use its capabilities?
-    
-    private final static int END_OF_STREAM = -1;
-    private final static String INPUTSTREAM_CLOSED = "The underlying InputStream has been closed";
-
-    private final InputStream src;
     private final FilterInputStreamCache cache;
 
-    private boolean srcClosed = false;
     private int srcOffset = 0;
     private int mark = 0;
-    private boolean useCache = false;
-    private int cacheOffset = 0;
-
-    //TODO ensure that FilterInputStreamCache implementations are thread-safe
 
     /**
-     * @param cache The cache implementation
-     * @param src The source InputStream to cache reads for
+     * Constructor which uses an existing Cache from a CachingFilterInputStream,
+     * if inputStream is a CachingFilterInputStream.
+     *
+     * @param inputStream
      */
-    public CachingFilterInputStream(final FilterInputStreamCache cache, final InputStream src) {
-        super(src);
-        this.src = src;
-        this.cache = cache;
+    public CachingFilterInputStream(InputStream inputStream) throws InstantiationException {
+        super(null);
+
+        if (inputStream instanceof CachingFilterInputStream) {
+            this.cache = ((CachingFilterInputStream) inputStream).getCache();
+        } else {
+            throw new InstantiationException("Only CachingFilterInputStream are supported as InputStream");
+        }
     }
 
-    /**
-     * Constructor which uses an existing CachingFilterInputStream as its
-     * underlying InputStream
-     *
-     * The position in the stream and any mark is reset to zero
-     */
-    public CachingFilterInputStream(final CachingFilterInputStream cfis) {
-        this(cfis.getCache(), cfis);
-        this.srcClosed = cfis.srcClosed;
-        this.useCache = cfis.srcOffset > 0;
-        this.cacheOffset = cfis.cacheOffset; //TODO is this correct?
-        //this.srcOffset = cfis.srcOffset; //TODO is this correct?
+    public CachingFilterInputStream(final FilterInputStreamCache cache) {
+        super(null);
+        this.cache = cache;
     }
 
     /**
@@ -99,22 +87,8 @@ public class CachingFilterInputStream extends FilterInputStream {
 
     @Override
     public int available() throws IOException {
-
-        int available = 0;
-
-        if(!srcClosed) {
-
-            available = src.available();
-
-            if(useCache && cacheOffset < srcOffset) {
-                available += getCache().getLength() - cacheOffset;
-            }
-        }
-
-        return available;
+        return getCache().available() - srcOffset;
     }
-
-
 
     @Override
     public synchronized void mark(final int readLimit) {
@@ -128,40 +102,28 @@ public class CachingFilterInputStream extends FilterInputStream {
 
     @Override
     public synchronized void reset() throws IOException {
-        useCache = true;
-        cacheOffset = mark;
+        srcOffset = mark;
     }
 
     @Override
     public int read() throws IOException {
 
-        if(srcClosed) {
-            throw new IOException(INPUTSTREAM_CLOSED);
+        if (getCache().isSrcClosed()) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
         }
 
-        if(useCache && cacheOffset < srcOffset) {
-            final int data = getCache().get(cacheOffset++);
-
-            //are we outside the cache
-            if(cacheOffset >= srcOffset) {
-                useCache = false;
-            }
+        //Read from cache
+        if (useCache()) {
+            final int data = getCache().get(srcOffset++);
             return data;
-
         } else {
-            final int data = src.read();
-
-            //have we reached the end of the stream?
-            if(data == END_OF_STREAM) {
-                return END_OF_STREAM;
-            }
-
-            //increment srcOffset due to read operation above
-            srcOffset++;
+            final int data = getCache().read();
             
-            //store data in cache
-            getCache().write(data);
-
+            if(data == FileFilterInputStreamCache.END_OF_STREAM) {
+                return FilterInputStreamCache.END_OF_STREAM;
+            }
+            
+            srcOffset++;
             return data;
         }
     }
@@ -174,32 +136,28 @@ public class CachingFilterInputStream extends FilterInputStream {
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
 
-        if(srcClosed) {
-            throw new IOException(INPUTSTREAM_CLOSED);
+        if (getCache().isSrcClosed()) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
         }
 
-        if(useCache /* && cacheOffset < srcOffset */) {
+        if (useCache()) {
 
             //copy data from the cache
-            int actualLen = (len > getCache().getLength() - cacheOffset ? getCache().getLength() - cacheOffset : len);
-            getCache().copyTo(cacheOffset, b, off, actualLen);
-            cacheOffset += actualLen;
+            int actualLen = (len > getCache().getLength() - this.srcOffset ? getCache().getLength() - this.srcOffset : len);
+            getCache().copyTo(this.srcOffset, b, off, actualLen);
+            this.srcOffset += actualLen;
 
             //if the requested bytes were more than what is present in the cache, then also read from the src
-            if(actualLen < len) {
-                useCache = false;
-                int srcLen = src.read(b, off + actualLen, len - actualLen);
+            if (actualLen < len) {
+                int srcLen = getCache().read(b, off + actualLen, len - actualLen);
 
                 //have we reached the end of the stream?
-                if(srcLen == END_OF_STREAM) {
+                if (srcLen == FilterInputStreamCache.END_OF_STREAM) {
                     return actualLen;
                 }
 
                 //increase srcOffset due to the read opertaion above
                 srcOffset += srcLen;
-
-                //store data in cache
-                getCache().write(b, off + actualLen, srcLen);
 
                 actualLen += srcLen;
             }
@@ -207,18 +165,15 @@ public class CachingFilterInputStream extends FilterInputStream {
             return actualLen;
 
         } else {
-            int actualLen = src.read(b, off, len);
+            int actualLen = getCache().read(b, off, len);
 
             //have we reached the end of the stream?
-            if(actualLen == END_OF_STREAM) {
+            if (actualLen == FilterInputStreamCache.END_OF_STREAM) {
                 return actualLen;
             }
 
             //increase srcOffset due to read operation above
             srcOffset += actualLen;
-
-            //store data in cache
-            getCache().write(b, off, actualLen);
 
             return actualLen;
         }
@@ -229,71 +184,69 @@ public class CachingFilterInputStream extends FilterInputStream {
      */
     @Override
     public void close() throws IOException {
-        if(!srcClosed) {
-            try {
-                src.close();
-            } finally {
-                srcClosed = true;
-            }
-        }
-        getCache().invalidate(); //empty the cache
+        if(!getCache().isSrcClosed()) {
+            getCache().close();
+        }    
     }
-
-
+    
     /**
      * We cant actually skip as we need to read so that we can cache the data,
-     * however apart from the potentially increased I/O
-     * and Memory, the end result is the same
+     * however apart from the potentially increased I/O and Memory, the end
+     * result is the same
      */
     @Override
-    public long skip(final long n) throws IOException {
+    public long skip(final long len) throws IOException {
 
-        if(srcClosed) {
-            throw new IOException(INPUTSTREAM_CLOSED);
-        } else if(n < 1) {
+        if (getCache().isSrcClosed()) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
+        } else if (len < 1) {
             return 0;
         }
 
-        if(useCache && cacheOffset < srcOffset) {
+        if (useCache()) {
 
             //skip data from the cache
-            long actualLen = (n > getCache().getLength() - cacheOffset ? getCache().getLength() - cacheOffset : n);
-            cacheOffset += actualLen;
+            long actualLen = (len > getCache().getLength() - this.srcOffset ? getCache().getLength() - this.srcOffset : len);
 
             //if the requested bytes were more than what is present in the cache, then also read from the src
-            if(actualLen < n) {
-                useCache = false;
-                
-                final byte skipped[] = new byte[(int)(n - actualLen)];
-                int srcLen = src.read(skipped);
+            if (actualLen < len) {
+                final byte skipped[] = new byte[(int) (len - actualLen)];
+                int srcLen = getCache().read(skipped);
 
                 //have we reached the end of the stream?
-                if(srcLen == END_OF_STREAM) {
+                if (srcLen == FilterInputStreamCache.END_OF_STREAM) {
                     return actualLen;
                 }
 
                 //increase srcOffset due to the read operation above
                 srcOffset += srcLen;
 
-                //store data in cache
-                getCache().write(skipped, 0, srcLen);
-                
                 actualLen += srcLen;
             }
             return actualLen;
 
         } else {
 
-            final byte skipped[] = new byte[(int)n];  //TODO could overflow
-            int actualLen = src.read(skipped);
+            final byte skipped[] = new byte[(int) len];  //TODO could overflow
+            int actualLen = getCache().read(skipped);
 
             //increase srcOffset due to read operation above
             srcOffset += actualLen;
 
-            //store data in the cache
-            getCache().write(skipped, 0, actualLen);
-
             return actualLen;
         }
+    }
+
+    private boolean useCache() {
+        //If cache hasRead and srcOffset is still in cache useCache
+        return getCache().getSrcOffset() > 0 && getCache().getLength() > srcOffset;
+    }
+    
+    public void register(InputStream inputStream) {
+        getCache().register(inputStream);
+    }
+    
+    public void deregister(InputStream inputStream) {
+        getCache().deregister(inputStream);
     }
 }

--- a/src/main/java/uk/org/adamretter/restream/TemporaryFileManager.java
+++ b/src/main/java/uk/org/adamretter/restream/TemporaryFileManager.java
@@ -49,92 +49,101 @@ import org.slf4j.LoggerFactory;
  * @author Adam Retter <adam.retter@googlemail.com>
  */
 public class TemporaryFileManager {
-    
+
     private final static Logger LOG = LoggerFactory.getLogger(TemporaryFileManager.class);
     
     private final static String FOLDER_PREFIX = "_mmtfm_";
     private final Stack<File> available = new Stack<File>();
     private final File tmpFolder;
-    
+
     private final static TemporaryFileManager instance = new TemporaryFileManager();
-    
+
     public static TemporaryFileManager getInstance() {
         return instance;
     }
-    
+
     private TemporaryFileManager() {
         final String tmpDir = System.getProperty("java.io.tmpdir");
         final File t = new File(tmpDir);
-        
+
         cleanupOldTempFolders(t);
-        
+
         this.tmpFolder = new File(t, FOLDER_PREFIX + UUID.randomUUID().toString());
-        if(!tmpFolder.mkdir()) {
-            throw new RuntimeException("Unable to use temporary folder: " +  tmpFolder.getAbsolutePath());
+        if (!tmpFolder.mkdir()) {
+            throw new RuntimeException("Unable to use temporary folder: " + tmpFolder.getAbsolutePath());
         }
-        
+
         LOG.info("Temporary folder is: " + tmpFolder.getAbsolutePath());
     }
-    
+
     public final File getTemporaryFile() throws IOException {
-        
+
         File tempFile = null;
-        
-        synchronized(available) {
-            if(!available.empty()) {
+
+        synchronized (available) {
+            if (!available.empty()) {
                 tempFile = available.pop();
             }
         }
-        
-        if(tempFile == null) {
+
+        if (tempFile == null) {
             tempFile = File.createTempFile("mmtf_" + System.currentTimeMillis(), ".tmp", tmpFolder);
-        
+
             //add hook to JVM to delete the file on exit
             //unfortunately this does not always work on all (e.g. Windows) platforms
             tempFile.deleteOnExit();
         }
-        
+
         return tempFile;
     }
-    
+
     public void returnTemporaryFile(final File tempFile) {
-        
-        //attempt to delete the temporary file
-        final boolean deleted = tempFile.delete();
-        
-        if(deleted) {
-            LOG.debug("Deleted temporary file: " + tempFile.getAbsolutePath());
-        } else {
-            LOG.debug("Could not delete temporary file: " + tempFile.getAbsolutePath() + ". Returning to stack for re-use.");
-            
-            //if we couldnt delete it, add it to the stack of available files
-            //for reuse in the future.
-            //Typically there are problems deleting these files on Windows
-            //platforms which is why this facility was added
-            synchronized(available) {
-                available.push(tempFile);
+        //Check if tempFile is still present ..
+        if (tempFile.exists()) {
+            final boolean deleted = tempFile.delete();
+
+            //attempt to delete the temporary file
+            if (deleted) {
+                LOG.debug("Deleted temporary file: " + tempFile.getAbsolutePath());
+            } else {
+                LOG.debug("Could not delete temporary file: " + tempFile.getAbsolutePath() + ". Returning to stack for re-use.");
+
+                //if we couldnt delete it, add it to the stack of available files
+                //for reuse in the future.
+                //Typically there are problems deleting these files on Windows
+                //platforms which is why this facility was added
+                synchronized (available) {
+                    //Check if tempFile is not allready present in stack ...
+                    if (available.contains(tempFile)) {
+                        LOG.debug("Temporary file: " + tempFile.getAbsolutePath() + " already in stack. Skipping.");
+                    } else {
+                        available.push(tempFile);
+                    }
+                }
             }
+        } else {
+            LOG.debug("Trying to delete non existing file: " + tempFile.getAbsolutePath());
         }
     }
-    
+
     private void cleanupOldTempFolders(final File t) {
-        final File oldFolders[] = t.listFiles(new FileFilter(){
+        final File oldFolders[] = t.listFiles(new FileFilter() {
             @Override
-            public boolean accept(final File f) {
+            public boolean accept(File f) {
                 return f.isDirectory() && f.getName().startsWith(FOLDER_PREFIX);
             }
         });
-        
-        for(final File oldFolder : oldFolders) {
+
+        for (final File oldFolder : oldFolders) {
             deleteFolder(oldFolder);
         }
     }
-    
+
     private void deleteFolder(final File folder) {
         try {
             FileUtils.deleteDirectory(folder);
             LOG.debug("Deleted temporary folder: " + folder.getAbsolutePath());
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             LOG.warn("Unable to delete temporary folder: " + folder.getAbsolutePath(), ioe);
         }
     }
@@ -142,10 +151,10 @@ public class TemporaryFileManager {
     @Override
     protected void finalize() throws Throwable {
         super.finalize();
-        
+
         //remove references to available files
         available.clear();
-        
+
         //try and remove our temporary folder
         deleteFolder(tmpFolder);
     }

--- a/src/main/java/uk/org/adamretter/restream/cache/AbstractFilterInputStreamCache.java
+++ b/src/main/java/uk/org/adamretter/restream/cache/AbstractFilterInputStreamCache.java
@@ -1,0 +1,198 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2015 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package uk.org.adamretter.restream.cache;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Vector;
+import uk.org.adamretter.restream.CachingFilterInputStream;
+
+/**
+ *
+ * @author zwobit
+ */
+public abstract class AbstractFilterInputStreamCache extends FilterInputStream implements FilterInputStreamCache {
+    protected Vector<InputStream> consumers = new Vector<InputStream>();
+    
+    private int srcOffset = 0;
+
+    private final InputStream src;
+    private boolean srcClosed = false;
+
+    public AbstractFilterInputStreamCache(InputStream src) {
+        super(src);
+        this.src = src;
+        //register src
+        this.register(src);
+        //if src is CachingFilterInputStream also register there so it can keep track of stream which rely on cache
+        if(src instanceof CachingFilterInputStream) {
+           ((CachingFilterInputStream) src).register(src);
+        }
+    }
+        
+    public int getSrcOffset() {
+        return this.srcOffset;
+    }
+
+    public boolean isSrcClosed() {
+        return srcClosed;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (this.srcClosed) {
+            return 0;
+        }
+
+        return src.available() + getLength();
+    }
+
+    @Override
+    /**
+     * Closes the src InputStream and empties the cache
+     */
+    public void close() throws IOException {
+        if(consumers.contains(src)) {
+            deregister(src);
+            if(consumers.size() <= 0) {
+                if (!srcClosed) {
+                    try {
+                        if(src instanceof CachingFilterInputStream) {
+                            ((CachingFilterInputStream) src).deregister(this);
+                        } else {
+                            src.close();
+                        }
+                    } finally {
+                        srcClosed = true;
+                    }  
+                }
+                this.invalidate(); //empty the cache
+            }
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (srcClosed) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
+        }
+
+        final int data = src.read();
+        if( data == FilterInputStreamCache.END_OF_STREAM) {
+            return FilterInputStreamCache.END_OF_STREAM;
+        }
+        
+        this.write(data);
+        this.srcOffset++;
+        return data;
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    ;
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (srcClosed) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
+        }
+
+        int srcLen = src.read(b, off, len);
+
+        if (srcLen == FilterInputStreamCache.END_OF_STREAM) {
+            return FilterInputStreamCache.END_OF_STREAM;
+        }
+
+        this.write(b, off, srcLen);
+        this.srcOffset += srcLen;
+        return srcLen;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (srcClosed) {
+            throw new IOException(FilterInputStreamCache.INPUTSTREAM_CLOSED);
+        } else if (n < 1) {
+            return 0;
+        }
+
+        if (srcOffset < n) {
+            final byte skipped[] = new byte[(int) (n - srcOffset)];
+            int srcLen = src.read(skipped);
+
+            //have we reached the end of the stream?
+            if (srcLen == FilterInputStreamCache.END_OF_STREAM) {
+                return srcOffset;
+            }
+
+            //increase srcOffset due to the read operation above
+            srcOffset += srcLen;
+
+            //store data in cache
+            this.write(skipped, 0, srcLen);
+
+            return srcOffset;
+        } else {
+
+            final byte skipped[] = new byte[(int) n];  //TODO could overflow
+            int actualLen = src.read(skipped);
+
+            //increase srcOffset due to read operation above
+            srcOffset += actualLen;
+
+            //store data in the cache
+            this.write(skipped, 0, actualLen);
+
+            return actualLen;
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void mark(int readlimit) {
+    }
+
+    
+
+    @Override
+    public void reset() throws IOException {
+        throw new IOException("reset() not supported.");
+    }    
+
+    @Override
+    public void register(InputStream inputStream) {
+        consumers.add(inputStream);
+    }
+
+    @Override
+    public void deregister(InputStream inputStream) {
+        consumers.remove(inputStream);
+    }
+
+    
+}

--- a/src/main/java/uk/org/adamretter/restream/cache/FilterInputStreamCache.java
+++ b/src/main/java/uk/org/adamretter/restream/cache/FilterInputStreamCache.java
@@ -27,6 +27,7 @@
 package uk.org.adamretter.restream.cache;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Interface for Cache Implementations for use by the CachingFilterInputStream
@@ -35,34 +36,39 @@ import java.io.IOException;
  * @version 1.0
  */
 public interface FilterInputStreamCache {
+    public final static int END_OF_STREAM = -1;
+    public final static String INPUTSTREAM_CLOSED = "The underlying InputStream has been closed";
 
     //TODO ensure that FilterInputStreamCache implementations are enforced thread-safe
-
     /**
-     * Writes len bytes from the specified byte array starting at offset off to the cache.
-     * The general contract for write(b, off, len) is that some of the bytes in the array b
-     * are written to the output stream in order; element b[off] is the first byte written
-     * and b[off+len-1] is the last byte written by this operation.
+     * Writes len bytes from the specified byte array starting at offset off to
+     * the cache. The general contract for write(b, off, len) is that some of
+     * the bytes in the array b are written to the output stream in order;
+     * element b[off] is the first byte written and b[off+len-1] is the last
+     * byte written by this operation.
      *
      * If b is null, a NullPointerException is thrown.
      *
-     * If off is negative, or len is negative, or off+len is greater than the length of the array b, then an IndexOutOfBoundsException is thrown.
+     * If off is negative, or len is negative, or off+len is greater than the
+     * length of the array b, then an IndexOutOfBoundsException is thrown.
      *
      * @param b the data.
      * @param off the start offset in the data.
      * @param len - the number of bytes to write.
      *
-     * @throws IOException - if an I/O error occurs. In particular, an IOException is thrown if the cache is invalidated.
+     * @throws IOException - if an I/O error occurs. In particular, an
+     * IOException is thrown if the cache is invalidated.
      */
     public void write(byte b[], int off, int len) throws IOException;
 
     /**
-     * Writes the specified byte to the cache.
-     * The general contract for write is that one byte is written to the cache.
+     * Writes the specified byte to the cache. The general contract for write is
+     * that one byte is written to the cache.
      *
      * @param i - the byte.
      *
-     * @throws IOException if an I/O error occurs. In particular, an IOException may be thrown if cache is invalidated.
+     * @throws IOException if an I/O error occurs. In particular, an IOException
+     * may be thrown if cache is invalidated.
      */
     public void write(int i) throws IOException;
 
@@ -79,7 +85,8 @@ public interface FilterInputStreamCache {
      * @param off The offset to read from
      * @return The byte read from the offset
      *
-     * @throws IOException if an I/O error occurs. In particular, an IOException may be thrown if cache is invalidated.
+     * @throws IOException if an I/O error occurs. In particular, an IOException
+     * may be thrown if cache is invalidated.
      */
     public byte get(int off) throws IOException;
 
@@ -91,7 +98,8 @@ public interface FilterInputStreamCache {
      * @param off The offset in the buffer b at which to start writing
      * @param len The length of data to copy
      *
-     * @throws IOException if an I/O error occurs. In particular, an IOException may be thrown if cache is invalidated.
+     * @throws IOException if an I/O error occurs. In particular, an IOException
+     * may be thrown if cache is invalidated.
      */
     public void copyTo(int cacheOffset, byte b[], int off, int len) throws IOException;
 
@@ -100,7 +108,77 @@ public interface FilterInputStreamCache {
      *
      * Destroys the cache and releases any underlying resources
      *
-     * @throws IOException if an I/O error occurs. In particular, an IOException may be thrown if cache is already invalidated.
+     * @throws IOException if an I/O error occurs. In particular, an IOException
+     * may be thrown if cache is already invalidated.
      */
     public void invalidate() throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public int available() throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public void close() throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public void mark(int readlimit);
+
+    /**
+     * @see java.io.InputStream
+     */
+    public boolean markSupported();
+
+    /**
+     * @see java.io.InputStream
+     */
+    public abstract int read() throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public int read(byte[] b) throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public int read(byte[] b, int off, int len) throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public void reset() throws IOException;
+
+    /**
+     * @see java.io.InputStream
+     */
+    public long skip(long n) throws IOException;
+
+    /**
+     * Current offset in underlying InputStream
+     * @return srcOffset
+     */
+    public int getSrcOffset();
+
+    /**
+     * Check is underlying InputStream is closed
+     * @return isSrcClosed
+     */
+    public boolean isSrcClosed();
+        
+    /**
+     * Register InputStreams so cache can keep track on consumers
+     * @param inputStream 
+     */
+    public void register(InputStream inputStream);
+    
+    /**
+     * Deregister InputStreams from cache
+     * @param inputStream 
+     */
+    public void deregister(InputStream inputStream);
 }

--- a/src/main/java/uk/org/adamretter/restream/cache/MemoryFilterInputStreamCache.java
+++ b/src/main/java/uk/org/adamretter/restream/cache/MemoryFilterInputStreamCache.java
@@ -26,8 +26,8 @@
  */
 package uk.org.adamretter.restream.cache;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Cache implementation for CachingFilterInputStream
@@ -37,11 +37,11 @@ import java.io.IOException;
  *
  * @author Adam Retter <adam.retter@googlemail.com>
  */
-public class MemoryFilterInputStreamCache implements FilterInputStreamCache {
+public class MemoryFilterInputStreamCache extends AbstractFilterInputStreamCache {
+private java.io.ByteArrayOutputStream cache = new java.io.ByteArrayOutputStream();
 
-    private ByteArrayOutputStream cache = new ByteArrayOutputStream();
-
-    public MemoryFilterInputStreamCache() {
+    public MemoryFilterInputStreamCache(InputStream src) {
+        super(src);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class MemoryFilterInputStreamCache implements FilterInputStreamCache {
 
     @Override
     public void invalidate() throws IOException {
-        if(cache != null) {
+        if (cache != null) {
             cache.close();
             cache = null;
         }
@@ -80,10 +80,9 @@ public class MemoryFilterInputStreamCache implements FilterInputStreamCache {
     /**
      * Updates to the cache are not reflected in the underlying input stream
      */
-    
     //TODO refactor this so that updates to the cache are reflected
     /*@Override
-    public InputStream getIndependentInputStream() {
-        return new ByteArrayInputStream(cache.toByteArray());
-    }*/
+     public InputStream getIndependentInputStream() {
+     return new ByteArrayInputStream(cache.toByteArray());
+     }*/
 }

--- a/src/main/java/uk/org/adamretter/restream/cache/MemoryMappedFileFilterInputStreamCache.java
+++ b/src/main/java/uk/org/adamretter/restream/cache/MemoryMappedFileFilterInputStreamCache.java
@@ -30,6 +30,7 @@ import uk.org.adamretter.restream.TemporaryFileManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -42,7 +43,7 @@ import java.nio.channels.FileChannel;
  *
  * @author Adam Retter <adam.retter@googlemail.com>
  */
-public class MemoryMappedFileFilterInputStreamCache implements FilterInputStreamCache {
+public class MemoryMappedFileFilterInputStreamCache extends AbstractFilterInputStreamCache {
 
     private final static long DEFAULT_MEMORY_MAP_SIZE = 64 * 1024 * 1024; //64MB
 
@@ -51,32 +52,37 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
     private MappedByteBuffer buf;
     private File tempFile = null;
     private final long memoryMapSize = DEFAULT_MEMORY_MAP_SIZE;
-    
+
     private boolean externalFile = true;
 
-    public MemoryMappedFileFilterInputStreamCache() throws IOException {
-        this(null);
+    public MemoryMappedFileFilterInputStreamCache(InputStream src) throws IOException {
+        this(src, null);
     }
-    
-    public MemoryMappedFileFilterInputStreamCache(final File f) throws IOException {
-        
-        if(f == null) {
+
+    public MemoryMappedFileFilterInputStreamCache(InputStream src, final File f) throws IOException {
+        super(src);
+
+        if (f == null) {
             tempFile = TemporaryFileManager.getInstance().getTemporaryFile();
             externalFile = false;
         } else {
             tempFile = f;
             externalFile = true;
         }
-        
+
         /**
          * Check the applicability of these bugs to this code:
-         *  http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
-         *  http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6417205 (fixed in 1.6)
+         * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
+         * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6417205 (fixed in
+         * 1.6)
          */
-        
-        this.raf =  new RandomAccessFile(tempFile, "rw");
+        this.raf = new RandomAccessFile(tempFile, "rw");
         this.channel = raf.getChannel();
         this.buf = channel.map(FileChannel.MapMode.READ_WRITE, 0, getMemoryMapSize());
+    }
+
+    private void setTempFile(File f) {
+
     }
 
     private long getMemoryMapSize() {
@@ -86,12 +92,12 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
     private void increaseSize(final long bytes) throws IOException {
 
         long factor = (bytes / getMemoryMapSize());
-        if(factor == 0 || bytes % getMemoryMapSize() > 0) {
+        if (factor == 0 || bytes % getMemoryMapSize() > 0) {
             factor++;
         }
 
         buf.force();
-        
+
         //TODO revisit this based on the comment below, I now believe setting position in map does work, but you have to have the correct offset added in as well! Adam
         final int position = buf.position();
         buf = channel.map(FileChannel.MapMode.READ_WRITE, 0, buf.capacity() + (getMemoryMapSize() * factor));
@@ -102,7 +108,7 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
 
-        if(buf.remaining() < len) {
+        if (buf.remaining() < len) {
             //we need to remap the file
             increaseSize(len - buf.remaining());
         }
@@ -113,18 +119,18 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
     @Override
     public void write(final int i) throws IOException {
 
-        if(buf.remaining() < 1) {
+        if (buf.remaining() < 1) {
             //we need to remap the file
             increaseSize(1);
         }
 
-        buf.put((byte)i);
+        buf.put((byte) i);
     }
 
     @Override
     public byte get(final int off) throws IOException {
 
-       if(off > buf.capacity()) {
+        if (off > buf.capacity()) {
             //we need to remap the file
             increaseSize(off - buf.capacity());
         }
@@ -140,7 +146,7 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
     @Override
     public void copyTo(final int cacheOffset, final byte[] b, final int off, final int len) throws IOException {
 
-        if(off + len > buf.capacity()) {
+        if (off + len > buf.capacity()) {
             //we need to remap the file
             increaseSize(off + len - buf.capacity());
         }
@@ -169,9 +175,9 @@ public class MemoryMappedFileFilterInputStreamCache implements FilterInputStream
         channel.close();
         raf.close();
         //System.gc();
-        
-        if(tempFile != null && (!externalFile)) {
-           TemporaryFileManager.getInstance().returnTemporaryFile(tempFile);
+
+        if (tempFile != null && (!externalFile)) {
+            TemporaryFileManager.getInstance().returnTemporaryFile(tempFile);
         }
     }
 }

--- a/src/test/java/uk/org/adamretter/restream/CachingFilterInputStreamTest.java
+++ b/src/test/java/uk/org/adamretter/restream/CachingFilterInputStreamTest.java
@@ -35,6 +35,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Random;
 import org.junit.Test;
 import uk.org.adamretter.restream.cache.FileFilterInputStreamCache;
@@ -76,20 +78,22 @@ public class CachingFilterInputStreamTest {
         this.cacheClass = cacheClass;
     }
 
-    private FilterInputStreamCache getNewCache() throws InstantiationException, IllegalAccessException {
-        return cacheClass.newInstance();
+    private FilterInputStreamCache getNewCache(InputStream is) throws InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
+        Constructor ctor = cacheClass.getDeclaredConstructor(InputStream.class);
+        ctor.setAccessible(true);
+        return (FilterInputStreamCache)ctor.newInstance(is);
     }
 
     @Test
-    public void readByte() throws IOException, InstantiationException, IllegalAccessException {
+    public void readByte() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
-
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
+        
         //read the first 3 bytes
         assertEquals(testData[0], cfis.read());
         assertEquals(testData[1], cfis.read());
@@ -141,13 +145,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test(expected = IOException.class)
-    public void readByte_onClosedStream() throws IOException, InstantiationException, IllegalAccessException {
+    public void readByte_onClosedStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         assertEquals(testData[0], cfis.read());
 
@@ -158,14 +162,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readByte_pastEndOfStream_fromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readByte_pastEndOfStream_fromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "he";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         cfis.mark(Integer.MAX_VALUE);
 
@@ -183,14 +187,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readByte_pastEndOfStream() throws IOException, InstantiationException, IllegalAccessException {
+    public void readByte_pastEndOfStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read all the bytes upto end of stream
         int b = -1;
@@ -205,13 +209,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readByte_allFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readByte_allFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "hello";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -235,14 +239,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read the first 3 bytes
         byte result[] = new byte[3];
@@ -303,13 +307,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test(expected = IOException.class)
-    public void readBytes_onClosedStream() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_onClosedStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         final byte result[] = new byte[2];
         cfis.read(result);
@@ -322,14 +326,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_pastEndOfStream() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_pastEndOfStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         final byte result[] = new byte[testData.length];
         int read = cfis.read(result);
@@ -343,14 +347,14 @@ public class CachingFilterInputStreamTest {
     }
     
     @Test
-    public void readBytes_pastEndOfStream_fromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_pastEndOfStream_fromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         cfis.mark(Integer.MAX_VALUE);
 
@@ -376,13 +380,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_allFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_allFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "hello";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -404,13 +408,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_partFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_partFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -432,13 +436,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_withZeroOffset_allFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_withZeroOffset_allFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "hello";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -460,13 +464,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_withZeroOffset_partFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_withZeroOffset_partFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -488,13 +492,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void readBytes_withOffsetAndLength_allFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void readBytes_withOffsetAndLength_allFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark the position
         cfis.mark(Integer.MAX_VALUE);
@@ -523,13 +527,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void skip() throws IOException, InstantiationException, IllegalAccessException {
+    public void skip() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read the first 3 bytes
         assertEquals(testData[0], cfis.read());
@@ -546,13 +550,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void skip_partFromCache() throws IOException, InstantiationException, IllegalAccessException {
+    public void skip_partFromCache() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read the first 2 bytes
         assertEquals(testData[0], cfis.read());
@@ -588,13 +592,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test(expected = IOException.class)
-    public void skip_onClosedStream() throws IOException, InstantiationException, IllegalAccessException {
+    public void skip_onClosedStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         cfis.close();
 
@@ -603,13 +607,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void skip_negativeBytes() throws IOException, InstantiationException, IllegalAccessException {
+    public void skip_negativeBytes() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //should cause IOException
         final long skipped = cfis.skip(-1);
@@ -617,13 +621,13 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onClosedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onClosedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         cfis.close();
 
@@ -631,11 +635,11 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onEmptyStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onEmptyStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final InputStream is = new ByteArrayInputStream(new byte[]{});
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         cfis.close();
 
@@ -643,26 +647,26 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onUnCachedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onUnCachedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         assertEquals(testData.length, cfis.available());
     }
 
     @Test
-    public void available_onPartiallyReadStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onPartiallyReadStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read first 2 bytes
         cfis.read();
@@ -672,14 +676,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onPartiallyCachedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onPartiallyCachedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark for later reset
         cfis.mark(Integer.MAX_VALUE);
@@ -695,14 +699,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onOffsetPartiallyCachedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onOffsetPartiallyCachedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read first 2 bytes
         cfis.read();
@@ -722,14 +726,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onCachedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onCachedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //mark for later reset
         cfis.mark(Integer.MAX_VALUE);
@@ -745,14 +749,14 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void available_onOffsetCachedStream()  throws IOException, InstantiationException, IllegalAccessException {
+    public void available_onOffsetCachedStream()  throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final String testString = "helloWorld";
         final byte testData[] = testString.getBytes();
 
         final InputStream is = new ByteArrayInputStream(testData);
 
-        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis = new CachingFilterInputStream(getNewCache(is));
 
         //read first 2 bytes
         cfis.read();
@@ -772,28 +776,29 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void constructed_from_CachingFilterInputStream() throws InstantiationException, IllegalAccessException, IOException {
+    public void constructed_from_CachingFilterInputStream() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         
         final byte[] testData = generateRandomData(_12KB);
         final InputStream is = new ByteArrayInputStream(testData);
         
         //first CachingFilterInputStream
-        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(is));
+        
         
         //second CachingFilterInputStream wraps first CachingFilterInputStream
-        final CachingFilterInputStream cfis2 = new CachingFilterInputStream(getNewCache(), cfis1);
+        final CachingFilterInputStream cfis2 = new CachingFilterInputStream(getNewCache(cfis1));
         
         assertArrayEquals(testData, consumeInputStream(cfis2));
     }
 
     @Test
-    public void constructed_from_CachingFilterInputStream_consumed() throws InstantiationException, IllegalAccessException, IOException {
+    public void constructed_from_CachingFilterInputStream_consumed() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final byte[] testData = generateRandomData(_12KB);
         final InputStream is = new NonMarkableByteArrayInputStream(testData);
 
         //first CachingFilterInputStream
-        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(is));
 
         assertArrayEquals(testData, consumeInputStream(cfis1));
 
@@ -804,13 +809,13 @@ public class CachingFilterInputStreamTest {
     }
     
     @Test
-    public void constructed_from_CachingFilterInputStream_partiallyConsumed() throws InstantiationException, IllegalAccessException, IOException {
+    public void constructed_from_CachingFilterInputStream_partiallyConsumed() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
 
         final byte[] testData = generateRandomData(_12KB);
         final InputStream is = new NonMarkableByteArrayInputStream(testData);
 
         //first CachingFilterInputStream
-        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(is));
 
         //read first 6KB
         final byte firstPart[] = new byte[_6KB];
@@ -832,16 +837,16 @@ public class CachingFilterInputStreamTest {
      * a mark()
      */
     @Test
-    public void interleavedSourceReads() throws InstantiationException, IllegalAccessException, IOException {
+    public void interleavedSourceReads() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final byte[] testData = generateRandomData(_64KB);
         final InputStream is = new NonMarkableByteArrayInputStream(testData);
 
-        final FilterInputStreamCache cache1 = getNewCache();
+        final FilterInputStreamCache cache1 = getNewCache(is);
 
-        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(cache1, is);
+        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(cache1);
         cfis1.mark(Integer.MAX_VALUE);
 
-        final CachingFilterInputStream cfis2 = new CachingFilterInputStream(cache1, is);
+        final CachingFilterInputStream cfis2 = new CachingFilterInputStream(cache1);
 
         final byte result1[] = new byte[_12KB];
         cfis1.read(result1);
@@ -853,12 +858,12 @@ public class CachingFilterInputStreamTest {
     }
 
     @Test
-    public void sharedCacheWritesInOrder() throws InstantiationException, IllegalAccessException, IOException {
+    public void sharedCacheWritesInOrder() throws IOException, InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         final byte[] testData = generateRandomData(_64KB);
         final InputStream is = new NonMarkableByteArrayInputStream(testData);
         
         //first CachingFilterInputStream
-        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(), is);
+        final CachingFilterInputStream cfis1 = new CachingFilterInputStream(getNewCache(is));
         
         //read first 6KB
         final byte cfis1Part1[] = new byte[_6KB];


### PR DESCRIPTION
- moved 'src' handling from CachingFilterInputStream into Caches, added AbstractFilterInputStreamCache which handles basic 'src' handling functions and keeps track of 'consumers', Caches extend AbstractFilterInputStreamCache now.
- fix wrong constant-ref
